### PR TITLE
Update buildconfig.yaml

### DIFF
--- a/utilities/collectl/buildconfig.yaml
+++ b/utilities/collectl/buildconfig.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     dockerfile: |
       FROM registry.access.redhat.com/ubi7/ubi:7.8
-      RUN yum install http://archives.fedoraproject.org/pub/archive/epel/epel-release-latest-7.noarch.rpm -y && \
+      RUN yum install https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm -y && \
           yum install collectl-4.3.0-5.el7 pciutils hostname sysvinit-tools -y && \
           yum clean all
       COPY ./entrypoint.sh /root/

--- a/utilities/collectl/buildconfig.yaml
+++ b/utilities/collectl/buildconfig.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     dockerfile: |
       FROM registry.access.redhat.com/ubi7/ubi:7.8
-      RUN yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y && \
+      RUN yum install http://archives.fedoraproject.org/pub/archive/epel/epel-release-latest-7.noarch.rpm -y && \
           yum install collectl-4.3.0-5.el7 pciutils hostname sysvinit-tools -y && \
           yum clean all
       COPY ./entrypoint.sh /root/


### PR DESCRIPTION
As the original dl.fedoraproject.org url has been deprecated I adapted the BC to use the archives.fedoraproject.org url instead. Tested and working over OCP 4.14