### PR TITLE
Update buildconfig.yaml

### DIFF
--- a/utilities/collectl/buildconfig.yaml
+++ b/utilities/collectl/buildconfig.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     dockerfile: |
       FROM registry.access.redhat.com/ubi7/ubi:7.8
-      RUN yum install http://archives.fedoraproject.org/pub/archive/epel/epel-release-latest-7.noarch.rpm -y && \
+      RUN yum install https://archives.fedoraproject.org/pub/archive/epel/7/x86_64/Packages/e/epel-release-7-14.noarch.rpm -y && \
           yum install collectl-4.3.0-5.el7 pciutils hostname sysvinit-tools -y && \
           yum clean all
       COPY ./entrypoint.sh /root/

--- a/utilities/collectl/buildconfig.yaml
+++ b/utilities/collectl/buildconfig.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     dockerfile: |
       FROM registry.access.redhat.com/ubi7/ubi:7.8
-      RUN yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm -y && \
+      RUN yum install http://archives.fedoraproject.org/pub/archive/epel/epel-release-latest-7.noarch.rpm -y && \
           yum install collectl-4.3.0-5.el7 pciutils hostname sysvinit-tools -y && \
           yum clean all
       COPY ./entrypoint.sh /root/


### PR DESCRIPTION
The old dl.fedoraproject.org url is deprecated and it moved to http://archives.fedoraproject.org/pub/archive/epel/ . I adjusted the url since the 7server folder doesn't exist anymore. Tested in Openshift 4.14.